### PR TITLE
Add missing s1o exception includes

### DIFF
--- a/spatial_adapters/rtree_disk.hpp
+++ b/spatial_adapters/rtree_disk.hpp
@@ -21,11 +21,10 @@
 #pragma once
 
 #include <s1o/types.hpp>
+#include <s1o/exceptions.hpp>
 #include <s1o/transforms/transform_deref.hpp>
 #include <s1o/transforms/transform_get_tuple_element.hpp>
 #include <s1o/helpers/rtree_indexer_byval.hpp>
-
-#include <s1o/exceptions.hpp>
 
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point.hpp>

--- a/spatial_adapters/rtree_disk_slim.hpp
+++ b/spatial_adapters/rtree_disk_slim.hpp
@@ -21,11 +21,10 @@
 #pragma once
 
 #include <s1o/types.hpp>
+#include <s1o/exceptions.hpp>
 #include <s1o/transforms/transform_deref.hpp>
 #include <s1o/transforms/transform_get_tuple_element.hpp>
 #include <s1o/helpers/rtree_indexer_byval.hpp>
-
-#include <ex3/exceptions.hpp>
 
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point.hpp>


### PR DESCRIPTION
The include used was `ex3/exceptions.hpp` but there were exception classes from `s1o/exceptions.hpp`