### PR TITLE
Add destroy method to spatial adapters

### DIFF
--- a/dataset.hpp
+++ b/dataset.hpp
@@ -621,8 +621,8 @@ public:
     }
 
     /**
-     * @brief Destroy the class, unmapping any mapped pointers
-     * and closing any file descriptors.
+     * @brief Destroy the class, unmapping any mapped pointers and closing any
+     * file descriptors.
      *
      */
     virtual ~_dataset_fd_base()
@@ -1006,6 +1006,7 @@ public:
  * @note TSpatialAdapterImpl object must expose the following methods:
  *
  *  - bounds
+ *  - destroy
  *  - empty
  *  - equals
  *  - get_extra_files
@@ -2813,6 +2814,16 @@ public:
         init_spstruct_mem(true); // We are creating a new dataset
         if (!_fds.no_data())
             set_data_offsets_from_storage();
+    }
+
+    /**
+     * @brief Destroy the class and, if necessary, destroy the spatial storage
+     * if needed.
+     *
+     */
+    virtual ~dataset()
+    {
+        _spatial_adapter.destroy(_spatial_storage);
     }
 
     /**

--- a/spatial_adapters/rtree.hpp
+++ b/spatial_adapters/rtree.hpp
@@ -469,6 +469,18 @@ struct spatial_adapter_impl
     {
         return drop_const_s_iterator(tuple_get_second_s_iterator(st.end()));
     }
+
+    /**
+     * @brief Destroy the spatial storage, if necessary.
+     *
+     * @param st A reference to the spatial storage object.
+     */
+    void destroy(
+        spatial_storage_type& st
+    ) const
+    {
+        (void)st;
+    }
 };
 
 };

--- a/spatial_adapters/rtree_disk.hpp
+++ b/spatial_adapters/rtree_disk.hpp
@@ -807,6 +807,18 @@ struct spatial_adapter_impl
         return deref_s_iterator(tuple_get_second_iterator(st._rtree->end()),
             transform_s_deref(st._rvec.begin()));
     }
+
+    /**
+     * @brief Destroy the spatial storage, if necessary.
+     *
+     * @param st A reference to the spatial storage object.
+     */
+    void destroy(
+        spatial_storage_type& st
+    ) const
+    {
+        (void)st;
+    }
 };
 
 };

--- a/spatial_adapters/rtree_disk_slim.hpp
+++ b/spatial_adapters/rtree_disk_slim.hpp
@@ -742,6 +742,18 @@ struct spatial_adapter_impl
     {
         return tuple_get_second_iterator(st._rtree->end());
     }
+
+    /**
+     * @brief Destroy the spatial storage, if necessary.
+     *
+     * @param st A reference to the spatial storage object.
+     */
+    void destroy(
+        spatial_storage_type& st
+    ) const
+    {
+        (void)st;
+    }
 };
 
 };


### PR DESCRIPTION
Enables a wide range of spatial storages that require dynamic memory allocation